### PR TITLE
Fix memory leak while rendering the user avatar (fixes #51)

### DIFF
--- a/src/lua/ui/canvas.lua
+++ b/src/lua/ui/canvas.lua
@@ -245,8 +245,9 @@ end
 
 function Canvas:paint_image (x, y, image)
   cairo_set_source_surface (self.context, image, x, y)
-
   cairo_paint (self.context)
+
+  cairo_surface_destroy (image)
 end
 
 return Canvas

--- a/src/lua/ui/image.lua
+++ b/src/lua/ui/image.lua
@@ -18,9 +18,6 @@ function Image:new (canvas, file_path, size)
   o.width = o.size
   o.height = o.size
 
-  o.glob = o.canvas:create_image (o.file_path)
-  o.downscale = o.size / o.glob.width
-
   return o
 end
 
@@ -30,13 +27,16 @@ function Image:locate (x, y)
 end
 
 function Image:render ()
+  local glob = self.canvas:create_image (self.file_path)
+  local downscale = self.size / glob.width
+
   -- Fix top-left coordinates before scaling
-  local dx = (1 - self.downscale) * self.x
-  local dy = (1 - self.downscale) * self.y - self.size
+  local dx = (1 - downscale) * self.x
+  local dy = (1 - downscale) * self.y - self.size
 
-  self.canvas:apply_transform (self.downscale, 0, 0, self.downscale, dx, dy)
+  self.canvas:apply_transform (downscale, 0, 0, downscale, dx, dy)
 
-  self.canvas:paint_image (self.x, self.y, self.glob.image)
+  self.canvas:paint_image (self.x, self.y, glob.image)
 
   self.canvas:restore_transform ()
 end


### PR DESCRIPTION
It turns out that every surface in cairo context should be disposed after
each rendering cycle, so we take care of destroy the surface object responsible
to draw the png image of the avatar.

Fixes #51